### PR TITLE
fix configuration example

### DIFF
--- a/src/yang/example-qos-configuration-a.1.1.xml
+++ b/src/yang/example-qos-configuration-a.1.1.xml
@@ -13,7 +13,7 @@
     xmlns:qt="urn:ietf:params:xml:ns:yang:iana-qos-types">
   <classifier>
     <name>my-classifier</name>
-    <filter-operation>qt:match-all</filter-operation>
+    <filter-operation>match-all</filter-operation>
     <filter>
       <type>qt:dscp</type>
       <logical-not>true</logical-not>
@@ -33,7 +33,7 @@
         </source-port>
         <source-port
           xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
-          <source-port-min>l7540</source-port-min>
+          <source-port-min>17540</source-port-min>
           <source-port-max>19800</source-port-max>
         </source-port>
     </filter>

--- a/src/yang/example-qos-configuration-a.1.2.xml
+++ b/src/yang/example-qos-configuration-a.1.2.xml
@@ -22,10 +22,10 @@
             </dscp>
         </filter>
       </inline>
-      <action
-        xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
-	    <type>qt:dscp-marking</type>
-        <dscp>
+      <action>
+        <type>qt:dscp-marking</type>
+        <dscp
+          xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
           <dscp>23</dscp>
         </dscp>
       </action>


### PR DESCRIPTION
UT
Validating yang/example-qos-configuration-a.1.1.xml
Validating yang/example-qos-configuration-a.1.2.xml
Validating yang/example-qos-configuration-a.1.3.xml
../src/insert-figures.sh draft-ietf-rtgwg-qos-model-10.xml > tmp; mv tmp draft-ietf-rtgwg-qos-model-10.xml
xml2rfc draft-ietf-rtgwg-qos-model-10.xml -o draft-ietf-rtgwg-qos-model-10.txt --text
/app/draft/draft-ietf-rtgwg-qos-model-10.xml(4309): Warning: Artwork too wide, reducing indentation from 0 to 0
/app/draft/draft-ietf-rtgwg-qos-model-10.xml(4307): Warning: Figure too wide, reducing indentation from 3 to 0
/app/draft/draft-ietf-rtgwg-qos-model-10.xml(4306): Warning: Section too wide, reducing indentation from 0 to 0
/app/draft/draft-ietf-rtgwg-qos-model-10.xml(4215): Warning: Section too wide, reducing indentation from 0 to 0
/app/draft/draft-ietf-rtgwg-qos-model-10.xml(2726): Warning: Back too wide, reducing indentation from 0 to 0
/app/draft/draft-ietf-rtgwg-qos-model-10.xml(4309): Warning: Too long line found (L5031), 8 characters longer than 72 characters: 
    https://networklessons.com/quality-of-service/policing-configuration-example
 Created file draft-ietf-rtgwg-qos-model-10.txt
idnits draft-ietf-rtgwg-qos-model-10.txt
idnits 2.17.1 

draft-ietf-rtgwg-qos-model-10.txt:
