### PR TITLE
Fix scheduler example

### DIFF
--- a/draft/draft-ietf-rtgwg-qos-model.xml
+++ b/draft/draft-ietf-rtgwg-qos-model.xml
@@ -922,6 +922,14 @@ INSERT_TEXT_FROM_FILE(../src/yang/example-qos-configuration-a.1.4.xml)
     ]]></artwork>
         </figure>
       </section>
+      <section title="Configuration example for QoS Scheduling">
+        <figure>
+	  <name>Configuration example for QoS Scheduling</name>
+          <artwork><![CDATA[
+INSERT_TEXT_FROM_FILE(../src/yang/example-qos-configuration-a.1.5.xml)
+    ]]></artwork>
+        </figure>
+      </section>
     </section>
   </back>
 </rfc>

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -7,7 +7,6 @@ if [ ! -d ../bin/yang-parameters ]; then
    rsync -avz --delete rsync.iana.org::assignments/yang-parameters ../bin/
 fi
 
-pyang --ietf --lint --strict --canonical -p ../bin/yang-parameters  -p ../bin -f tree --max-line-length=72 --tree-line-length=69  ../bin/ietf-traffic-policy\@$(date +%Y-%m-%d).yang ../bin/ietf-qos-action\@$(date +%Y-%m-%d).yang ../bin/ietf-diffserv\@$(date +%Y-%m-%d).yang ../bin/iana-qos-types\@$(date +%Y-%m-%d).yang ../bin/ietf-queue-policy\@$(date +%Y-%m-%d).yang ../bin/ietf-scheduler-policy\@$(date +%Y-%m-%d).yang > output-tree.txt.tmp
 for i in ../bin/ietf-*\@$(date +%Y-%m-%d).yang
 do
     name=$(echo $i | cut -f 1-3 -d '.')

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -88,7 +88,7 @@ for i in yang/example-qos-configuration-a.*.*.xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
-    response=`yanglint -ii -t config -p ../bin/yang-parameters -p ../bin ../bin/ietf-diffserv\@$(date +%Y-%m-%d).yang ../bin/ietf-qos-action\@$(date +%Y-%m-%d).yang ../bin/ietf-traffic-policy\@$(date +%Y-%m-%d).yang ../bin/yang-parameters/ietf-interfaces@2018-02-20.yang ../bin/yang-parameters/iana-if-type@2021-06-21.yang $name.xml`
+    response=`yanglint -ii -t config -p ../bin/yang-parameters -p ../bin ../bin/ietf-diffserv\@$(date +%Y-%m-%d).yang ../bin/ietf-qos-action\@$(date +%Y-%m-%d).yang ../bin/ietf-traffic-policy\@$(date +%Y-%m-%d).yang ../bin/ietf-scheduler-policy\@$(date +%Y-%m-%d).yang ../bin/yang-parameters/ietf-interfaces@2018-02-20.yang ../bin/yang-parameters/iana-if-type@2021-06-21.yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -7,6 +7,7 @@ if [ ! -d ../bin/yang-parameters ]; then
    rsync -avz --delete rsync.iana.org::assignments/yang-parameters ../bin/
 fi
 
+pyang --ietf --lint --strict --canonical -p ../bin/yang-parameters  -p ../bin -f tree --max-line-length=72 --tree-line-length=69  ../bin/ietf-traffic-policy\@$(date +%Y-%m-%d).yang ../bin/ietf-qos-action\@$(date +%Y-%m-%d).yang ../bin/ietf-diffserv\@$(date +%Y-%m-%d).yang ../bin/iana-qos-types\@$(date +%Y-%m-%d).yang ../bin/ietf-queue-policy\@$(date +%Y-%m-%d).yang ../bin/ietf-scheduler-policy\@$(date +%Y-%m-%d).yang > output-tree.txt.tmp
 for i in ../bin/ietf-*\@$(date +%Y-%m-%d).yang
 do
     name=$(echo $i | cut -f 1-3 -d '.')

--- a/src/yang/example-qos-configuration-a.1.5.xml
+++ b/src/yang/example-qos-configuration-a.1.5.xml
@@ -1,0 +1,164 @@
+<!--
+    This example shows a QoS policy configuration for queuing.
+    For a description of the problem refer to:
+    https://networklessons.com/quality-of-service/queuing-configuration-example
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+
+<policies
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-traffic-policy"
+    xmlns:qt="urn:ietf:params:xml:ns:yang:iana-qos-types">
+  <policy>
+    <name>QUEUEING-POLICY</name>
+    <type>qt:queue-policy-type</type>
+    <classifier>
+      <name>VOICE</name>
+      <inline> 
+        <filter>
+          <type>qt:traffic-group-name</type>
+          <logical-not>false</logical-not>
+          <traffic-group
+    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+            <name>voice</name>
+          </traffic-group>
+        </filter>
+      </inline> 
+      <action>
+	<type>qt:queue</type>
+	<queue xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+	  <priority>
+	    <level>1</level>
+	  </priority>
+	  <min-rate>
+	    <value>2000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </min-rate>
+	  <max-rate>
+	    <value>4000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </max-rate>
+  	</queue>
+      </action>
+    </classifier>
+    <classifier>
+      <name>VIDEO</name>
+      <inline> 
+        <filter>
+          <type>qt:traffic-group-name</type>
+          <logical-not>false</logical-not>
+          <traffic-group
+    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+            <name>video</name>
+          </traffic-group>
+        </filter>
+      </inline> 
+      <action>
+	<type>qt:queue</type>
+	<queue
+	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+	  <priority>
+	    <level>2</level>
+	  </priority>
+	  <min-rate>
+	    <value>10000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </min-rate>
+	  <max-rate>
+	    <value>30000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </max-rate>
+	</queue>
+      </action>
+    </classifier>
+    <classifier>
+      <name>DATA</name>
+      <inline> 
+        <filter>
+          <type>qt:traffic-group-name</type>
+          <logical-not>false</logical-not>
+          <traffic-group
+    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+            <name>data</name>
+          </traffic-group>
+        </filter>
+      </inline> 
+      <action>
+	<type>qt:queue</type>
+	<queue
+	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+	  <priority>
+	    <level>2</level>
+	  </priority>
+	  <min-rate>
+	    <value>8000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </min-rate>
+	  <max-rate>
+	    <value>18000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </max-rate>
+	</queue>
+      </action>
+    </classifier>
+  </policy>
+</policies>
+
+<policies
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-traffic-policy"
+    xmlns:qt="urn:ietf:params:xml:ns:yang:iana-qos-types">
+  <policy>
+    <name>SCHEDULING-POLICY</name>
+    <type>qt:scheduler-policy-type</type>
+    <classifier>
+      <name>ALL</name>
+      <inline> 
+        <filter>
+          <type>qt:filter-match-all</type>
+          <logical-not>false</logical-not>
+          <match-all
+    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
+            <action></action>
+          </match-all>
+        </filter>
+      </inline> 
+      <action>
+	<type>qt:scheduler</type>
+	<scheduler
+    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
+	  <min-rate>
+	    <value>20000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </min-rate>
+	  <max-rate>
+	    <value>50000000</value>
+	    <unit>qt:bits-per-second</unit>
+	  </max-rate>
+	</scheduler>
+      </action>
+      <action>
+	<type>qt:queue-policy-name</type>
+	<queue-policy-name
+    	  xmln:sch="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
+          <queue-policy>QUEUEING-POLICY</queue-policy>
+	</queue-policy-name>
+      </action>
+    </classifier>
+  </policy>
+</policies>
+
+<interfaces
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces"
+    xmlns:qt="urn:ietf:params:xml:ns:yang:iana-qos-types"
+    xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">
+  <interface>
+    <name>FastEthernet 0/0</name>
+    <type>ianaift:ethernetCsmacd</type>
+    <qos-target-policy
+	xmlns="urn:ietf:params:xml:ns:yang:ietf-traffic-policy">
+      <direction>qt:egress</direction>
+      <type>qt:scheduling-policy-type</type>
+      <name>SCHEDULING-POLICY</name>
+    </qos-target-policy>
+  </interface>
+</interfaces>

--- a/src/yang/example-qos-configuration-a.1.5.xml
+++ b/src/yang/example-qos-configuration-a.1.5.xml
@@ -19,14 +19,14 @@
           <type>qt:traffic-group-name</type>
           <logical-not>false</logical-not>
           <traffic-group
-    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+	      xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
             <name>voice</name>
           </traffic-group>
         </filter>
       </inline> 
       <action>
 	<type>qt:queue</type>
-	<queue xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+	<queue xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
 	  <priority>
 	    <level>1</level>
 	  </priority>
@@ -48,7 +48,7 @@
           <type>qt:traffic-group-name</type>
           <logical-not>false</logical-not>
           <traffic-group
-    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+              xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
             <name>video</name>
           </traffic-group>
         </filter>
@@ -56,7 +56,7 @@
       <action>
 	<type>qt:queue</type>
 	<queue
-	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+            xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
 	  <priority>
 	    <level>2</level>
 	  </priority>
@@ -78,7 +78,7 @@
           <type>qt:traffic-group-name</type>
           <logical-not>false</logical-not>
           <traffic-group
-    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+              xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
             <name>data</name>
           </traffic-group>
         </filter>
@@ -86,7 +86,7 @@
       <action>
 	<type>qt:queue</type>
 	<queue
-	  xmlns="urn:ietf:params:xml:ns:yang:ietf-queue-policy">
+            xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
 	  <priority>
 	    <level>2</level>
 	  </priority>
@@ -102,11 +102,6 @@
       </action>
     </classifier>
   </policy>
-</policies>
-
-<policies
-    xmlns="urn:ietf:params:xml:ns:yang:ietf-traffic-policy"
-    xmlns:qt="urn:ietf:params:xml:ns:yang:iana-qos-types">
   <policy>
     <name>SCHEDULING-POLICY</name>
     <type>qt:scheduler-policy-type</type>
@@ -117,7 +112,7 @@
           <type>qt:filter-match-all</type>
           <logical-not>false</logical-not>
           <match-all
-    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
+              xmlns="urn:ietf:params:xml:ns:yang:ietf-diffserv">
             <action></action>
           </match-all>
         </filter>
@@ -125,7 +120,7 @@
       <action>
 	<type>qt:scheduler</type>
 	<scheduler
-    	  xmlns="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
+            xmlns="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
 	  <min-rate>
 	    <value>20000000</value>
 	    <unit>qt:bits-per-second</unit>
@@ -139,7 +134,7 @@
       <action>
 	<type>qt:queue-policy-name</type>
 	<queue-policy-name
-    	  xmln:sch="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
+            xmlns="urn:ietf:params:xml:ns:yang:ietf-scheduler-policy">
           <queue-policy>QUEUEING-POLICY</queue-policy>
 	</queue-policy-name>
       </action>
@@ -157,7 +152,7 @@
     <qos-target-policy
 	xmlns="urn:ietf:params:xml:ns:yang:ietf-traffic-policy">
       <direction>qt:egress</direction>
-      <type>qt:scheduling-policy-type</type>
+      <type>qt:scheduler-policy-type</type>
       <name>SCHEDULING-POLICY</name>
     </qos-target-policy>
   </interface>


### PR DESCRIPTION
Hi Aseem, I have made these changes on top of your diffs. The easiest way would be for you to accept these changes in your branch and work from there. Note, you will get my changes for issue 125, which you will need to be able even compile this example. Ideally, we should merge 125 before making any more changes. Concentrate on the a.1.5 example file, ignore the rest of the changes.

The example is still not compiling, but most of the "syntax" errors are gone. What we are left with is the logic piece. And here is what needs to be determined next. Either the error is in our module or the example. Basically, it is failing on the when statement:

```
    when "derived-from-or-self(../../traffic-policy:type, " +
         "'qos-types:ipv4-diffserv-policy-type') or " +
         "derived-from-or-self(../../traffic-policy:type, " +
         "'qos-types:ipv6-diffserv-policy-type') or " +
         "derived-from-or-self(../../traffic-policy:type, " +
         "'qos-types:diffserv-policy-type')" {

```

So either we have to further relax the when statement by adding the policy type of `queue-policy-type` and `scheduler-policy-type` or we change the type to one of the above types. I do not know what is the correct answer.

```
libyang err : When condition "derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='SCHEDULING-POLICY'][type='iana-qos-types:scheduler-policy-type']/classifier[name='ALL']/inline/filter[type='iana-qos-types:filter-match-all'][logical-not='false']/ietf-diffserv:match-all".)
libyang err : When condition "derived-from-or-self(../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='QUEUEING-POLICY'][type='iana-qos-types:queue-policy-type']/classifier[name='DATA']/action[type='iana-qos-types:queue']/ietf-diffserv:queue".)
libyang err : When condition "derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='QUEUEING-POLICY'][type='iana-qos-types:queue-policy-type']/classifier[name='DATA']/inline/filter[type='iana-qos-types:traffic-group-name'][logical-not='false']/ietf-diffserv:traffic-group".)
libyang err : When condition "derived-from-or-self(../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='QUEUEING-POLICY'][type='iana-qos-types:queue-policy-type']/classifier[name='VIDEO']/action[type='iana-qos-types:queue']/ietf-diffserv:queue".)
libyang err : When condition "derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='QUEUEING-POLICY'][type='iana-qos-types:queue-policy-type']/classifier[name='VIDEO']/inline/filter[type='iana-qos-types:traffic-group-name'][logical-not='false']/ietf-diffserv:traffic-group".)
libyang err : When condition "derived-from-or-self(../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='QUEUEING-POLICY'][type='iana-qos-types:queue-policy-type']/classifier[name='VOICE']/action[type='iana-qos-types:queue']/ietf-diffserv:queue".)
libyang err : When condition "derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv4-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:ipv6-diffserv-policy-type') or derived-from-or-self(../../../traffic-policy:type, 'qos-types:diffserv-policy-type')" not satisfied. (Data location "/ietf-traffic-policy:policies/policy[name='QUEUEING-POLICY'][type='iana-qos-types:queue-policy-type']/classifier[name='VOICE']/inline/filter[type='iana-qos-types:traffic-group-name'][logical-not='false']/ietf-diffserv:traffic-group".)
YANGLINT[E]: Failed to parse input data file "yang/example-qos-configuration-a.1.5.xml".
failed (error code: 0)
```