### PR TITLE
leafref changes for policy applied to interface, meter reference and queue reference

### DIFF
--- a/draft/draft-ietf-rtgwg-qos-model.xml
+++ b/draft/draft-ietf-rtgwg-qos-model.xml
@@ -236,9 +236,13 @@
 	    number of header fields; typically some combination of
 	    source address, destination address, DS field, protocol
 	    ID, source port and destination port.</li>
-	    <li>Per-Hop-Behavior (PHB): The externally observable
-	    forwarding behavior applied at a DS-compliant node to a DS
-	    behavior aggregate.</li>
+	    <li>Per-Hop-Behavior (PHB): A description of the externally
+            observable forwarding treatment applied at a differentiated
+            services-compliant node to a behavior aggregate
+            <xref target="RFC2474"></xref>. The description of a PHB
+            SHOULD be sufficiently detailed to allow the construction
+            of predictable services, as documented in
+            <xref target="RFC2475"></xref>.</li>
 	    <li>Policing: the process of
 	    discarding packets (by a dropper) within a traffic stream
 	    in accordance with the state of a corresponding meter

--- a/draft/draft-ietf-rtgwg-qos-model.xml
+++ b/draft/draft-ietf-rtgwg-qos-model.xml
@@ -206,6 +206,7 @@
 	    <li>Classifier: an entity which selects packets based on
 	    the content of packet headers according to defined
 	    rules.</li>
+            <li>CoDel: Controlled Delay AQM algorithm</li>
 	    <li>DS behavior aggregate: A collection of packets with
 	    the same DS codepoint crossing a link in a particular
 	    direction.</li>
@@ -220,6 +221,7 @@
 	    in network nodes.</li>
 	    <li>DSCP: Differentiated Services Code Point</li>
 	    <li>ECN: Explicit Congestion Notification</li>
+            <li>FQ-CoDel: Flow Queue Controlled Delay AQM algorithm</li>
 	    <li>Marking: the process of setting the DS codepoint in
             a packet based on defined rules; pre-marking, re-marking.
 	    </li>

--- a/src/yang/ietf-qos-action.yang
+++ b/src/yang/ietf-qos-action.yang
@@ -543,6 +543,27 @@ module ietf-qos-action {
       "Random Early Detect (RED) configuration parameters.";
   }
 
+  grouping codel-config-parameters {
+    leaf target {
+      type uint64;
+      units "microseconds";
+      default 5000;
+      description
+        "Target time in microseconds spent by each packet in queue.";
+    }
+
+    leaf interval {
+      type uint64;
+      units "microseconds";
+      default 100000;
+      description
+        "The time in microsecond for minimum interval for congestion
+         to persist before algorithm kicks in. ";
+    }
+    description
+      "CoDel configuration parameters.";
+  }
+
   grouping queue {
     container queue {
       uses priority;
@@ -626,12 +647,49 @@ module ietf-qos-action {
                 type boolean;
                 default "false";
                 description
-                  "ECN is enabled on the queue.";
+                  "When configure as true, ECN is enabled on
+                   the queue.";
               }
               description
                 "Weighted Random Early Detect (WRED) configuration.";
             }
           }
+
+          case codel {
+            container codel {
+              uses codel-config-parameters;
+              leaf ecn-enabled {
+                type boolean;
+                default "false";
+                description
+                  "When configure as true, ECN is enabled on
+                   the queue.";
+              }
+              description
+                "CoDel configuration.";
+            }
+          }
+
+          case fq-codel {
+            container fq-codel {
+              uses codel-config-parameters;
+              leaf flows {
+                type uint64;
+                default 1024;
+                description
+                  "The maximum number of flow queues.";
+              }
+              leaf ecn-enabled {
+                type boolean;
+                default "false";
+                description
+                  "ECN is enabled on the queue.";
+              }
+              description
+                "FQ-CoDel configuration.";
+            }
+          }
+
           description
             "Choice of Drop Algorithm.";
         }

--- a/src/yang/ietf-qos-action.yang
+++ b/src/yang/ietf-qos-action.yang
@@ -322,7 +322,10 @@ module ietf-qos-action {
   grouping meter-reference {
     container meter {
       leaf name {
-        type string ;
+        type leafref  {
+          path "/qos-action:meters/" +
+               "qos-action:meter/qos-action:name";
+        }
         mandatory true;    
         description
           "This leaf defines name of the meter referenced.";
@@ -663,7 +666,10 @@ module ietf-qos-action {
   grouping queue-reference {
     container queue-reference {
       leaf queue-name {
-        type string;
+        type leafref  {
+          path "/qos-action:queues/" +
+               "qos-action:queue/qos-action:name";
+        }
         mandatory true;
         description
           "This leaf defines name of the  queue template

--- a/src/yang/ietf-qos-oper.yang
+++ b/src/yang/ietf-qos-oper.yang
@@ -135,68 +135,111 @@ module ietf-qos-oper {
         "Total number of bytes tail-dropped.";
     }
 
-    leaf red-drop-pkts {
-      type yang:zero-based-counter64;
-      description
-        "Total number of packets dropped because of RED.";
-    }
-
-    leaf red-drop-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Total number of bytes dropped because of RED.";
-    }
-
-    leaf red-ecn-marked-pkts {
-      type yang:zero-based-counter64;
-      description
-        "Total number of packets that were marked with ECN
-         because of RED.";
-    }
-
-    leaf red-ecn-marked-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Total number of bytes that were marked with ECN because of
-         RED.";
-    }
-
-    list wred-stats {
-      config false;
-      description
-        "QoS WRED statistics.";
-
-      leaf profile {
-        type uint8;
-        description
-          "Profile identifier for each color of traffic.";
-      }
-
+    container red-statistics {
       leaf drop-pkts {
         type yang:zero-based-counter64;
         description
-          "Total number of packets dropped because of WRED.";
+          "Total number of packets dropped because of RED.";
       }
 
       leaf drop-bytes {
         type yang:zero-based-counter64;
         description
-          "Total number of bytes dropped because of WRED.";
+          "Total number of bytes dropped because of RED.";
       }
 
       leaf ecn-marked-pkts {
         type yang:zero-based-counter64;
         description
-          "Total number of packets that were marked with ECN because
-           of WRED.";
+          "Total number of packets that were marked with ECN
+           because of RED.";
       }
 
       leaf ecn-marked-bytes {
         type yang:zero-based-counter64;
         description
           "Total number of bytes that were marked with ECN because of
-           WRED.";
+           RED.";
       }
+
+      list wred-stats {
+        config false;
+        description
+          "QoS WRED statistics.";
+
+        leaf profile {
+          type uint8;
+          description
+            "Profile identifier for each color of traffic.";
+        }
+
+        leaf drop-pkts {
+          type yang:zero-based-counter64;
+          description
+            "Total number of packets dropped because of WRED.";
+        }
+
+        leaf drop-bytes {
+          type yang:zero-based-counter64;
+          description
+            "Total number of bytes dropped because of WRED.";
+        }
+
+        leaf ecn-marked-pkts {
+          type yang:zero-based-counter64;
+          description
+            "Total number of packets that were marked with ECN
+             because of WRED.";
+        }
+
+        leaf ecn-marked-bytes {
+          type yang:zero-based-counter64;
+          description
+            "Total number of bytes that were marked with ECN because
+             of WRED.";
+        }
+      }
+      description
+        "Container of all RED statistics.";
+    }
+
+    container codel-statistics {
+      leaf drop-pkts {
+        type yang:zero-based-counter64;
+        description
+          "Total number of packets dropped because of CoDel
+           or FQ-CoDel.";
+      }
+
+      leaf drop-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Total number of bytes dropped because of CoDel
+           or FQ-CoDel.";
+      }
+
+      leaf ecn-marked-pkts {
+        type yang:zero-based-counter64;
+        description
+          "Total number of packets that were marked with ECN
+           because of CoDel or FQ-CoDel.";
+      }
+
+      leaf ecn-marked-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Total number of bytes that were marked with ECN because
+           of CoDel or FQ-CoDel.";
+      }
+
+      leaf new-flow-count {
+        type yang:zero-based-counter64;
+        description
+          "Total number of flows that FQ-CoDel has identified and is
+           managing or has managed.";
+      }
+      description
+        "Container of all CoDel or FQ-CoDel statistics.";
     }
   }
 

--- a/src/yang/ietf-traffic-policy.yang
+++ b/src/yang/ietf-traffic-policy.yang
@@ -227,7 +227,10 @@ module ietf-traffic-policy {
       }
 
       leaf name {
-        type string;
+        type leafref  {
+          path "/traffic-policy:policies/" +
+              "traffic-policy:policy/traffic-policy:name";
+        }
         mandatory true;
         description
           "A unique name for the Policy.";

--- a/src/yang/ietf-traffic-policy.yang
+++ b/src/yang/ietf-traffic-policy.yang
@@ -167,7 +167,13 @@ module ietf-traffic-policy {
           "Classifier configuration in a policy.";
 
         leaf name {
-          type string;
+          type union {
+            type string;
+            type leafref {
+              path "/traffic-policy:classifiers/" +
+              "traffic-policy:classifier/traffic-policy:name";
+            }
+          }
           description
             "A unique name for classifier entry.";
         }


### PR DESCRIPTION
Three leafref is added for consideration:

1. Policy Name Applied to Interface.
2. Meter Template reference used in meter-reference grouping.
3. Queue Template reference used in queue-reference grouping.